### PR TITLE
Mob spawners slowly tick with no nearby players

### DIFF
--- a/Spigot-Server-Patches/0568-Monumenta-Mob-spawners-slowly-tick-with-no-nearby-pl.patch
+++ b/Spigot-Server-Patches/0568-Monumenta-Mob-spawners-slowly-tick-with-no-nearby-pl.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hazerd <dransom96@gmail.com>
+Date: Fri, 26 Jun 2020 21:02:03 -0400
+Subject: [PATCH] Monumenta - Mob spawners slowly tick with no nearby players
+
+
+diff --git a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
+index df494d37be687860878c2709ae7996510118a559..36e490013a05fc1e37c561b3dcd60c0be974b92b 100644
+--- a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
++++ b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
+@@ -59,6 +59,12 @@ public abstract class MobSpawnerAbstract {
+         if (spawnDelay > 0 && --tickDelay > 0) return;
+         tickDelay = this.a().paperConfig.mobSpawnerTickRate;
+         // Paper end
++		// Monumenta start - Mob spawners slowly tick with no nearby players
++		int adjustedTickDelay = tickDelay - 1;
++		if (spawnDelay > 0) {
++			spawnDelay -= 1;
++		}
++		// Monumenta end
+         if (!this.h()) {
+             this.f = this.e;
+         } else {
+@@ -73,18 +79,18 @@ public abstract class MobSpawnerAbstract {
+                 world.addParticle(Particles.SMOKE, d0, d1, d2, 0.0D, 0.0D, 0.0D);
+                 world.addParticle(Particles.FLAME, d0, d1, d2, 0.0D, 0.0D, 0.0D);
+                 if (this.spawnDelay > 0) {
+-                    this.spawnDelay -= tickDelay; // Paper
++                    this.spawnDelay -= adjustedTickDelay; // Paper // Monumenta
+                 }
+ 
+                 this.f = this.e;
+                 this.e = (this.e + (double) (1000.0F / ((float) this.spawnDelay + 200.0F))) % 360.0D;
+             } else {
+-                if (this.spawnDelay < -tickDelay) { // Paper
++                if (this.spawnDelay < -adjustedTickDelay) { // Paper // Monumenta
+                     this.i();
+                 }
+ 
+                 if (this.spawnDelay > 0) {
+-                    this.spawnDelay -= tickDelay; // Paper
++                    this.spawnDelay -= adjustedTickDelay; // Paper // Monumenta
+                     return;
+                 }
+ 


### PR DESCRIPTION
This allows spawners to "reprime" themselves after being left alone for a while.
The speed is based on the paper mob-spawner-tick-rate setting.
If the setting is N, spawners with no nearby players tick at 1/N speed.